### PR TITLE
Implement Travis-CI build test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: r
+pandoc_version: 2.7
+
+install: true
+
+script: make

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ RM=/bin/rm
 ifeq ($(OS),Windows_NT)
     PANDOC=/cygdrive/c/Program\ Files/Pandoc/pandoc.exe
 else
-    PANDOC=/usr/local/bin/pandoc
+    PANDOC=pandoc
 endif
 
 # Included date as command-line option workaround as per https://github.com/jgm/pandoc/issues/2865#issuecomment-257105573


### PR DESCRIPTION
Additional change made: pandoc is now referred to simply by name (allowing the value in the user's PATH to be used rather than a fixed location, except for Cygwin (Windows) users).